### PR TITLE
Add locale name (it, en, es) to label

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -283,7 +283,7 @@
 
 							<div ng-repeat="(localeName, localeValue) in filteredLocales" class="col  country-column" style="margin-top:5px;width: 20%;">
 								<input type="checkbox" id="{{ localeName }}" ng-model="settings.selectedLocales[localeName]"/>
-								<label for="{{ localeName }}" class="country-name" ng-class="{'text--selected': settings.selectedLocales[localeName]}">{{ localeValue }}</label>
+								<label for="{{ localeName }}" class="country-name" ng-class="{'text--selected': settings.selectedLocales[localeName]}">{{ localeValue }} ( {{ localeName }} )</label>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
When using this greta tool, often users have to reference another tab to get the language code. With it in the label, now everything can be done in one place! The language code (en, es, it) should be in the checkbox label with this pull request.